### PR TITLE
Use Guzzle query params array for api requests

### DIFF
--- a/Controller/Adminhtml/Index/ProductData.php
+++ b/Controller/Adminhtml/Index/ProductData.php
@@ -208,9 +208,9 @@ class ProductData extends Action
                 foreach ($storeArray as $store) {
                     $product = $this->productRepository->getById($productId, false, $store);
                     $language = $this->data->getStoreLanguage($store);
-                    $icecatUri = $this->data->getIcecatUri($product, $language);
-                    if ($icecatUri) {
-                        $response = $this->icecatApiService->execute($icecatUri);
+                    $icecatQuery = $this->data->getIcecatQuery($product, $language);
+                    if ($icecatQuery) {
+                        $response = $this->icecatApiService->execute($icecatQuery);
                         if (!empty($response) && !empty($response['Code'])) {
                             $errorMessage = $response['Message'];
                         } else {

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -159,16 +159,16 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     }
 
     /**
-     * @return mixed
+     * @return bool|array
      */
-    public function getIcecatUri(Product $product, $language)
+    public function getIcecatQuery(Product $product, $language): bool|array
     {
         $username = $this->getUsername();
         if (!empty($this->getGTINCode())) {
             $gtinCode = $this->getGTINCode();
             $gtinCodeData = $product->getData($gtinCode);
             if (!empty($gtinCodeData)) {
-                return '?UserName=' . $username . '&Language=' . $language . '&GTIN=' . $gtinCodeData;
+                return ['UserName' => $username, 'Language' => $language, 'GTIN' => $gtinCodeData];
             } elseif (!empty($this->getProductCode()) && !empty($this->getBrandCode())) {
                 $productCode = $this->getProductCode();
                 $brandCode = $this->getBrandCode();
@@ -181,7 +181,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
                 }
 
                 if (!empty($productCodeData) && !empty($brandCodeData)) {
-                    return '?UserName=' . $username . '&Language=' . $language . '&Brand=' . $brandCodeData . '&ProductCode=' . $productCodeData;
+                    return ['UserName' => $username, 'Language' => $language, 'Brand' => $brandCodeData, 'ProductCode' => $productCodeData];
                 }
             }
         } elseif (!empty($this->getProductCode()) && !empty($this->getBrandCode())) {
@@ -196,12 +196,12 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             }
             
             if (!empty($productCodeData) && !empty($brandCodeData)) {
-                return '?UserName=' . $username . '&Language=' . $language . '&Brand=' . $brandCodeData . '&ProductCode=' . $productCodeData;
+                return ['UserName' => $username, 'Language' => $language, 'Brand' => $brandCodeData, 'ProductCode' => $productCodeData];
             } elseif (!empty($this->getGTINCode())) {
                 $gtinCode = $this->getGTINCode();
                 $gtinCodeData = $product->getData($gtinCode);
                 if (!empty($gtinCodeData)) {
-                    return '?UserName=' . $username . '&Language=' . $language . '&GTIN=' . $gtinCodeData;
+                    return ['UserName' => $username, 'Language' => $language, 'GTIN' => $gtinCodeData];
                 }
             }
         }

--- a/Model/Queue.php
+++ b/Model/Queue.php
@@ -419,9 +419,9 @@ class Queue
                         foreach ($storeArray as $store) {
                             $product = $this->productRepository->getById($productId, false, $store);
                             $language = $this->data->getStoreLanguage($store);
-                            $icecatUri = $this->data->getIcecatUri($product, $language);
-                            if ($icecatUri) {                                
-                                $response = $this->icecatApiService->execute($icecatUri);
+                            $icecatQuery = $this->data->getIcecatQuery($product, $language);
+                            if ($icecatQuery) {                                
+                                $response = $this->icecatApiService->execute($icecatQuery);
                                 $responseArray[$store] = $response;
                                 if (!empty($response) && !empty($response['Code'])) {
                                     $errorMessage       = $this->errorMessageResponse($response, $product);

--- a/Service/IcecatApiService.php
+++ b/Service/IcecatApiService.php
@@ -42,9 +42,9 @@ class IcecatApiService
      * @param $icecatUri
      * @return array
      */
-    public function execute($icecatUri): array
+    public function execute(array $icecatQuery): array
     {
-        $response = $this->doRequest($icecatUri);
+        $response = $this->doRequest('', ['query'=> $icecatQuery]);
         $responseBody = $response->getBody();
         return json_decode($responseBody->getContents(), true);
     }
@@ -71,9 +71,10 @@ class IcecatApiService
         $userType = $this->data->getUserType();
         
         if($userType == 'full' && !empty($this->data->getAppKey())) {
-            $uriEndpoint = $uriEndpoint . '&app_key=' . $this->data->getAppKey();
+            $params['query']['app_key'] = $this->data->getAppKey();
         }
-        $uriEndpoint = $uriEndpoint . '&PlatformName=Magento2OpensourceExtension&PlatformVersion=V2';
+        $params['query']['PlatformName'] = 'Magento2OpensourceExtension';
+        $params['query']['PlatformVersion'] = 'V2';
 
         $params['headers'] = [
             'api-token' => $this->data->getAccessToken()


### PR DESCRIPTION
Queries to the Icecat API were previously constructed by concatenating all query parameters. This pull request uses the `$params['query']` argument of the Guzzle library to manage the query parameters, so all parameters are encoded correctly.