### PR TITLE
Fixed error “Not registered handle” on admin grid

### DIFF
--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -2,28 +2,6 @@
 
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
 
-    <type name="Magento\Framework\View\Element\UiComponent\DataProvider\CollectionFactory">
-        <arguments>
-            <argument name="collections" xsi:type="array">
-                <item name="cms_page_listing_data_source" xsi:type="string">Magento\Cms\Model\ResourceModel\Page\Grid\Collection</item>
-                <item name="cms_block_listing_data_source" xsi:type="string">Magento\Cms\Model\ResourceModel\Block\Grid\Collection</item>
-                <item name="sales_order_grid_data_source" xsi:type="string">Magento\Sales\Model\ResourceModel\Order\Grid\Collection</item>
-                <item name="sales_order_invoice_grid_data_source" xsi:type="string">Magento\Sales\Model\ResourceModel\Order\Invoice\Grid\Collection</item>
-                <item name="sales_order_shipment_grid_data_source" xsi:type="string">Magento\Sales\Model\ResourceModel\Order\Shipment\Grid\Collection</item>
-                <item name="sales_order_creditmemo_grid_data_source" xsi:type="string">Magento\Sales\Model\ResourceModel\Order\Creditmemo\Grid\Collection</item>
-                <item name="customer_listing_data_source" xsi:type="string">Magento\Customer\Model\ResourceModel\Grid\Collection</item>
-                <item name="customer_online_grid_data_source" xsi:type="string">Magento\Customer\Model\ResourceModel\Online\Grid\Collection</item>
-                <item name="customer_group_listing_data_source" xsi:type="string">Magento\Customer\Model\ResourceModel\Group\Grid\Collection</item>
-                <item name="url_rewrite_listing_data_source" xsi:type="string">Magento\UrlRewrite\Ui\Component\UrlRewrite\DataProvider\SearchResult</item>
-                <item name="search_synonyms_grid_data_source" xsi:type="string">Magento\Search\Model\ResourceModel\Synonyms\Grid\Collection</item>
-                <item name="pagebuilder_template_grid_data_source" xsi:type="string">Magento\PageBuilder\Model\ResourceModel\Template\Grid\Collection</item>
-                <item name="design_config_listing_data_source" xsi:type="string">Magento\Theme\Model\ResourceModel\Design\Config\Grid\Collection</item>
-                <item name="design_theme_listing_data_source" xsi:type="string">Magento\Theme\Ui\Component\Theme\DataProvider\SearchResult</item>
-                <item name="bulk_listing_data_source" xsi:type="string">Magento\AsynchronousOperations\Ui\Component\DataProvider\SearchResult</item>
-            </argument>
-        </arguments>
-    </type>
-
     <virtualType name="Magento\Catalog\Ui\DataProvider\Product\Form\Modifier\Pool">
         <arguments>
             <argument name="modifiers" xsi:type="array">
@@ -53,27 +31,13 @@
                 </item>
             </argument>
         </arguments>
-    </virtualType>
-    <type name="Magento\Framework\View\Element\UiComponent\DataProvider\CollectionFactory">
-        <arguments>
-            <argument name="collections" xsi:type="array">
-                <item name="icecat_queue_report_listing_data_source" xsi:type="string">Icecat\DataFeed\Model\ResourceModel\IcecatDatafeedQueue\Grid\Collection</item>
-            </argument>
-        </arguments>
-    </type> 
+    </virtualType> 
     <virtualType name="Icecat\DataFeed\Model\ResourceModel\IcecatDatafeedQueue\Grid\Collection" type="Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult">
         <arguments> 
             <argument name="mainTable" xsi:type="string">icecat_datafeed_queue</argument>
             <argument name="resourceModel" xsi:type="string">Icecat\DataFeed\Model\ResourceModel\IcecatDatafeedQueue</argument>
         </arguments>
     </virtualType>
-    <type name="Magento\Framework\View\Element\UiComponent\DataProvider\CollectionFactory">
-        <arguments>
-            <argument name="collections" xsi:type="array">
-                <item name="icecat_queue_log_report_listing_data_source" xsi:type="string">Icecat\DataFeed\Model\ResourceModel\IcecatDatafeedQueueLog\Grid\Collection</item>
-            </argument>
-        </arguments>
-    </type>
      <virtualType name="Icecat\DataFeed\Model\ResourceModel\IcecatDatafeedQueueLog\Grid\Collection" type="Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult">
         <arguments>
             <argument name="mainTable" xsi:type="string">icecat_datafeed_queue_log</argument>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -9,4 +9,18 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Framework\View\Element\UiComponent\DataProvider\CollectionFactory">
+        <arguments>
+            <argument name="collections" xsi:type="array">
+                <item name="icecat_queue_report_listing_data_source" xsi:type="string">Icecat\DataFeed\Model\ResourceModel\IcecatDatafeedQueue\Grid\Collection</item>
+            </argument>
+        </arguments>
+    </type>
+    <type name="Magento\Framework\View\Element\UiComponent\DataProvider\CollectionFactory">
+        <arguments>
+            <argument name="collections" xsi:type="array">
+                <item name="icecat_queue_log_report_listing_data_source" xsi:type="string">Icecat\DataFeed\Model\ResourceModel\IcecatDatafeedQueueLog\Grid\Collection</item>
+            </argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
### Description

Admin grid breaks and getting Error "Not registered handle" with the Exception. When we try to edit the page using page builder and try to insert image using html code, not registered handle Error will appear on display. This error also appears on custom grids. This Issue appears because the collection argument types are placed into area-specific file etc/adminhtml/di.xml, Magento used collection arguments at the global level etc/di.xml. The area-specific file overrides the global value. It can lead to problems for other grids.

**Error screenshot**
![image](https://github.com/IcecatNV/magento-extension/assets/124759297/c1785420-86e8-46fa-8c50-c0e4f49f1990)

### Fixed Issues

**Fixed:** [Getting Error “Not registered handle” on Grid #10](https://github.com/IcecatNV/magento-extension/issues/10)
### Manual testing scenarios

1. Get the Magento clean shop.
2. Install Icecat_DataFeed module.
3. Navigate to the Content > Elements > Pages.
4. Edit any page (ex. Home page).
5. Go to content and edit the page builder. Add HTML code element. Click on the insert image button. 
It throws an error as mentioned.
