### PR TITLE
Fixed ACL permission issue

### DIFF
--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <acl>
+        <resources>
+            <resource id="Magento_Backend::admin">
+                <resource id="Magento_Backend::stores">
+                    <resource id="Magento_Backend::stores_settings">
+                        <resource id="Magento_Config::config">
+                             <resource id="Icecat_DataFeed::datafeed_configuration" title="Icecate Datafeed Configuration" translate="title" />   
+                        </resource>
+                    </resource>
+                </resource>
+            </resource>
+        </resources>
+    </acl>
+</config>


### PR DESCRIPTION
### Description
We can’t able to give permission to access module configuration settings for other roles. Administrator should give permission to module configuration for other roles and module configuration should be visible for another role user as well.

**Screenshot**
Here, you can see in screenshot 1 that, there is no resource available to give permission for this module configuration settings.
![image](https://github.com/IcecatNV/magento-extension/assets/124759630/f334497c-de9a-419a-8c57-de67ceb5974a)
so, In this module, there is no implemented ACL(Access Control List) for module configuration, that's why it is not showing in the role resource and the administrator can’t able to give permission to other roles.

### Fixed Issues
**Fixed:** [ACL role permission issue #12](https://github.com/IcecatNV/magento-extension/issues/12)

