### PR TITLE
Fixed module uninstall issue

### DIFF
--- a/Setup/Patch/Data/CreateProductAttribute.php
+++ b/Setup/Patch/Data/CreateProductAttribute.php
@@ -217,11 +217,9 @@ class CreateProductAttribute implements DataPatchInterface, PatchRevertableInter
         $this->moduleDataSetup->getConnection()->startSetup();
 
         // Deleting category
-        /* $connection = $this->moduleDataSetup->getConnection();
+        $connection = $this->moduleDataSetup->getConnection();
         $table = $connection->getTableName('core_config_data');
-        $category = $connection->getConnection()
-            ->query('SELECT value FROM ' . $table . ' WHERE path = "datafeed/icecat/root_category_id"')
-            ->fetch(); */
+        $category = $connection->query('SELECT value FROM ' . $table . ' WHERE path = "datafeed/icecat/root_category_id"')->fetch();
         $categoryId = $this->_scopeConfig->getValue('datafeed/icecat/root_category_id', \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
         if (!empty($categoryId)) {
             //$categoryId = $category['value'];
@@ -239,18 +237,14 @@ class CreateProductAttribute implements DataPatchInterface, PatchRevertableInter
                     $subCategory->delete();
                 }
             }
+        $this->categoryRepository->deleteByIdentifier($categoryId);
         }
 
-        $this->categoryRepository->deleteByIdentifier($categoryId);
-        $connection->getConnection()
-            ->query('Delete FROM ' . $table . ' WHERE path like "%datafeed%"')
-            ->fetch();
+        $connection->query('Delete FROM ' . $table . ' WHERE path like "%datafeed%"')->fetch();
 
         // Deleting patch data from patch_list table
         $patchTable = $connection->getTableName('patch_list');
-        $connection->getConnection()
-            ->query('Delete FROM ' . $patchTable . ' WHERE patch_name like "%Icecat%"')
-            ->fetch();
+        $connection->query('Delete FROM ' . $patchTable . ' WHERE patch_name like "%Icecat%"')->fetch();
 
         /** @var EavSetup $eavSetup */
         $eavSetup = $this->eavSetupFactory->create(['setup' => $this->moduleDataSetup]);

--- a/etc/db_schema_whitelist.json
+++ b/etc/db_schema_whitelist.json
@@ -65,7 +65,8 @@
             "error_log": true,
             "data_size": true,
             "created": true,
-            "locked_at": true
+            "locked_at": true,
+            "schedule_unique_id": true
         },
         "constraint": {
             "PRIMARY": true
@@ -83,7 +84,8 @@
             "product_ids": true,
             "product_ids_with_missing_gtin_product_code": true,
             "ended": true,
-            "error_log": true
+            "error_log": true,
+            "schedule_unique_id": true
         },
         "constraint": {
             "PRIMARY": true
@@ -96,6 +98,26 @@
             "data": true,
             "error_log": true,
             "data_size": true,
+            "created_at": true,
+            "schedule_unique_id": true
+        },
+        "constraint": {
+            "PRIMARY": true
+        }
+    },
+    "icecat_queue_scheduler": {
+        "column": {
+            "id": true,
+            "started": true,
+            "ended": true,
+            "type": true,
+            "status": true,
+            "product_updated": true,
+            "product_failed": true,
+            "queue_mode": true,
+            "cron_expression": true,
+            "cron_run_time": true,
+            "schedule_unique_id": true,
             "created_at": true
         },
         "constraint": {


### PR DESCRIPTION
### **Preconditions**
Magento Version : 2.4.6-p2
Module Version : 2.0.0
### **Description**
Whenever you try to uninstall the IceCat module, it gives you an error , and you cannot uninstall the module. Also, whenever you disable the IceCat module and run the setup:upgrade command, five out of six tables in the database, generated through the "db_schema.xml" file by this module, get deleted. However, the remaining table named "icecat_queue_schedule"' in the database didn't get deleted .
### **Fixed Issues**
Fixes https://github.com/IcecatNV/magento-extension/issues/15